### PR TITLE
Fix eligible address check

### DIFF
--- a/stealthdrop/packages/vite/src/hooks/useEligibleAddresses.tsx
+++ b/stealthdrop/packages/vite/src/hooks/useEligibleAddresses.tsx
@@ -20,17 +20,17 @@ export function useEligibleAddresses(addresses: Address[] | undefined): UseEligi
       };
     }
 
-    // TODO: remove mock
-    // const eligibleAddresses = addresses?.filter(
-    //   address => merkleTree.indexOf(BigInt(address)) !== -1,
-    // ) as `0x${string}`[];
+    const eligibleAddresses = (addresses ?? []).filter(
+      address => merkleTree.indexOf(BigInt(address)) !== -1,
+    ) as `0x${string}`[];
 
-    // const nonEligibleAddresses: string[] =
-    //   addresses?.filter(address => merkleTree.indexOf(BigInt(address)) === -1) ?? [];
+    const nonEligibleAddresses: string[] = (addresses ?? []).filter(
+      address => merkleTree.indexOf(BigInt(address)) === -1,
+    );
 
     return {
-      eligibleAddresses: ['0xe28b4B0C08a5A43529030A2F8444E4AEC00C9813'], // mock for demo
-      nonEligibleAddresses: addresses ?? [], // mock for demo
+      eligibleAddresses,
+      nonEligibleAddresses,
       isLoading: false,
     };
   }, [merkleTree, addresses]);


### PR DESCRIPTION
## Summary
- remove mock logic from useEligibleAddresses hook

## Testing
- `bun run test` *(fails: hardhat command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cbabe8624832786d661cb4c7ce42e